### PR TITLE
Add chmod to Dockerfile to set speedtestRunner as executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,5 @@ EXPOSE 443
 
 RUN chown -R nginx:nginx /var/www/html/
 RUN chmod +x /var/www/html/config/run.sh
+RUN chmod 755 /var/www/html/scripts/speedtestRunner.py
 ENTRYPOINT ["/var/www/html/config/run.sh"]


### PR DESCRIPTION
As per comments on #55 , sets `speedtestRunner.py` as executable.

fixes #55 