### PR TITLE
Set window/tab title using customTitle

### DIFF
--- a/js/evaluation.js
+++ b/js/evaluation.js
@@ -10,6 +10,7 @@ jQuery(document).ready(function(){
     };
     if (appConfig.customTitle){
         jQuery('#title').html(appConfig.customTitle);
+        window.document.title = appConfig.customTitle;
     }
     let data = {
         labels:[] ,


### PR DESCRIPTION
Just a minor thing, but I noticed that when you set the `customTitle` in your `appConfig.js` file, it only sets the title in the header, but not the title of the window/tab. This PR makes sure both are set.