### PR TITLE
Address frequent best server failures on the hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,21 @@ You can get the publicly available docker image at the following location: [roes
 The SpeedTest analyser should to run out of the box with docker.
 
 **Important:** To keep the history of speedtest within a rebuild of
-the container please moint a volume in ``/var/www/html/data/``
+the container please mount a volume in ``/var/www/html/data/``
 
 ### Setup:
-1. Moint host volume onto ``/var/www/html/data/``
+1. Mount host volume onto ``/var/www/html/data/``
 2. Map preferred host port on port _80_
 3. Build container from image
-4. Enjoy continious speed statistics after a while
+4. Enjoy continuous speed statistics after a while
 
 # Environment variables
 | Variable  | Type | Usage |  Example Value | Default |
 | ------------- | ------------- | ------------- | ------------- | ------------- |
 | CRONJOB_ITERATION  | INT  | Time between speedtests in minutes. Value 15 means the cronjob runs every 15 minutes. Keep undefined to run hourly. | 15 | 60 |
 | SPEEDTEST_PARAMS  | STRING  | append extra parameter for cli command.<br/> `speedtest-cli --simple $SPEEDTEST_PARAMS` <br/> Check [parameter documentation](https://github.com/sivel/speedtest-cli#usage)  | --mini https://speedtest.test.fr | none |
+| ON_HOUR_JITTER | INT | Maximum number of seconds to wait before running speedtest on the hour. Value 30 means speedtest will run after a random number of seconds between 0 and 30. This only occurs on the hour to minimize failures due to server overload. Value 0 will disable any wait. | 30 | 0 |
+| BEST_SERVER_ATTEMPTS | INT | Number of times to try `get_best_server()` before failing the test. `get_best_server()` frequently fails on the hour, so retrying improves the chance of getting results. A value less than 1 will result in 1 attempt | 8 | 10 |
 
 # Config
 You can configure the visualization frontend via ``appConfig.js``

--- a/scripts/speedtestRunner.py
+++ b/scripts/speedtestRunner.py
@@ -7,27 +7,63 @@
 import os
 import csv
 import datetime
+import random
 import time
-from speedtest import Speedtest
+from speedtest import Speedtest, SpeedtestBestServerFailure
 
 #static values
 CSV_FIELDNAMES=["timestamp", "ping", "download", "upload"]
 FILEPATH = os.path.dirname(os.path.abspath(__file__)) + '/../data/result.csv'
 
+def getIntEnv(varname, default):
+        try:
+                val = int(os.environ.get(varname, default))
+        except ValueError:
+                print('{}:{} should be an integer, defaulting to {}'.format(varname, os.environ.get(varname), default))
+                val = default
+        return val
+
+def onHourJitter():
+        '''speedtest is busiest on the hour so failure rate and performance suffer.
+           This method adds a random sleep to stagger on the hour speedtests to
+           reduce failures and potentially relieve load on speedtest servers'''
+
+        if datetime.datetime.now().minute != 0:
+                # only sleep on the hour
+                return
+
+        jitter = getIntEnv('ON_HOUR_JITTER', 0)
+        if jitter > 0:
+                slp = random.randint(0, jitter)
+                print('ON_HOUR_JITTER:{} sleeping {} seconds'.format(jitter, slp))
+                time.sleep(random.randint(0, jitter))
+
 def runSpeedtest():
         #run speedtest-cli
         print('--- running speedtest ---')
+
+        onHourJitter()
 
         #execute speedtest
         servers = []
         threads = None
 
+        result = {'ping': 0.0, 'download': 0.0, 'upload': 0.0}
         s = Speedtest()
-        s.get_servers(servers)
-        s.get_best_server()
-        s.download(threads=threads)
-        s.upload(threads=threads, pre_allocate=False)
-        result = s.results.dict()
+        attempts = getIntEnv('BEST_SERVER_ATTEMPTS', 10)
+        for i in range(max(1, attempts)):
+                s.get_servers(servers)
+                try:
+                        s.get_best_server()
+                        s.download(threads=threads)
+                        s.upload(threads=threads, pre_allocate=False)
+                        result = s.results.dict()
+                        break
+                except SpeedtestBestServerFailure:
+                        print('attempt {} of {} failed to get speeds, trying again'.format(i + 1, attempts))
+                        continue
+        else:
+                print('failed to get speeds, defaulting to 0.0')
 
         #collect speedtest data
         ping = round(result['ping'], 2)


### PR DESCRIPTION
Speedtest frequently fails to find the best server on the
hour. Google searches revealed this to be due to high
server load. To address this, I added a random sleep (jitter),
and retry attempts. Both can be configured and disabled
via environment variables.

Additionally, I defaulted the results to 0.0 so you can see
in the graph when speedtest failures occurred.
