### PR TITLE
Address various speedtest exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ the container please mount a volume in ``/var/www/html/data/``
 | ------------- | ------------- | ------------- | ------------- | ------------- |
 | CRONJOB_ITERATION  | INT  | Time between speedtests in minutes. Value 15 means the cronjob runs every 15 minutes. Keep undefined to run hourly. | 15 | 60 |
 | SPEEDTEST_PARAMS  | STRING  | append extra parameter for cli command.<br/> `speedtest-cli --simple $SPEEDTEST_PARAMS` <br/> Check [parameter documentation](https://github.com/sivel/speedtest-cli#usage)  | --mini https://speedtest.test.fr | none |
+| RETRY_ATTEMPTS | INT | Number of times to try speedtest before failing the test. Retrying improves the chance of getting results. A value less than 1 will result in 1 attempt | 8 | 10 |
 
 # Config
 You can configure the visualization frontend via ``appConfig.js``

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+    <meta charset="utf-8">
     <title>Speed Test Stats</title>
     <!-- css -->
     <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "name": "docker-speedtest-analyser",
-  "version": "v1.4",
+  "version": "v1.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/roest01/docker-speedtest-analyser.git"
   },
   "license": "MIT",
   "dependencies": {
-    "bootstrap": "^4.6.0",
-    "bootstrap-daterangepicker": "^3.1.0",
-    "chart.js": "^3.1.0",
+    "bootstrap": "twbs/bootstrap#v4.0.0-beta",
+    "bootstrap-daterangepicker": "dangrossman/bootstrap-daterangepicker#^2.1.25",
+    "chart.js": "nnnick/Chart.js#^2.7.0",
     "jquery": "jquery/jquery-dist#1.9.1 - 3",
-    "moment": "^2.29.1",
-    "papaparse": "4.3.7",
-    "popper.js": "^1.16.1"
+    "moment": "moment/moment#^2.19.3",
+    "papaparse": "mholt/PapaParse#^4.3.6",
+    "popper.js": "^1.14.7"
   },
   "engines": {
     "yarn": ">= 1.0.0"


### PR DESCRIPTION
Speedtest frequently fails to find the best server on the
hour. Google searches revealed this to be due to high
server load. To address this, I added a retry attempts
controlled by an environment variable.

I have also see speedtest fail to retrieve the config, so
I've included exception handling for it as 

Additionally, I defaulted the results to 0.0 so you can see
in the graph when speedtest failures 

Add missing utf-8 charset to index.html