### PR TITLE
Change js/appConfig.example so you don't have to remove `let`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ the container please mount a volume in ``/var/www/html/data/``
 # Config
 You can configure the visualization frontend via ``appConfig.js``
 copy the ``/js/appConfig.example.js`` into ``/data/appConfig.js`` (where your volume should be mounted).
-Change ``let appConfig = {`` to ``appConfig = {`` in /data/appConfig.js
 
 #### Libs used
 1. Bootstrap 4 - alpha

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
 
 
     <!-- custom -->
-    <script type="text/javascript" src="data/appConfig.js"></script>
     <script type="text/javascript" src="js/appConfig.example.js"></script>
+    <script type="text/javascript" src="data/appConfig.js"></script>
     <script type="text/javascript" src="js/evaluation.js"></script>
 
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico"/>

--- a/js/appConfig.example.js
+++ b/js/appConfig.example.js
@@ -1,30 +1,37 @@
 /**
  * To customize your settings:
  * 1. copy appConfig.example.js into /data/appConfig.js
- * 2. change "let appConfig = {" to "appConfig = {" in /data/appConfig.js
+ * 2. change values in /data/appConfig.js
  * 3. restart the container if it is already running
  */
-let appConfig = {
-  "customTitle": "Statistics",
-  "dateFormat": "DD.MM.YYYY",
-  "locale": "de",
-  "labels": {
-    "download": "Download",
-    "ping": "Ping",
-    "upload": "Upload"
-  },
-  "daterange": {
-    "timePicker": true,
-    "timePicker24Hour": true,
-    "startDate": moment().startOf('day'),
-    "endDate": moment().endOf('day'),
-    ranges: {
-      'Today': [moment().hours(0).minutes(0).seconds(0), moment().hours(23).minutes(59).seconds(59)],
-      'Yesterday': [moment().hours(0).minutes(0).seconds(0).subtract(1, 'days'), moment().hours(23).minutes(59).seconds(59).subtract(1, 'days')],
-      'Last 7 Days': [moment().subtract(6, 'days'), moment()],
-      'Last 30 Days': [moment().subtract(29, 'days'), moment()],
-      'This Month': [moment().startOf('month'), moment().endOf('month')],
-      'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
+if (typeof appConfig == 'undefined') {
+  var appConfig = {};
+}
+
+appConfig = {
+  ...appConfig,
+  ...{
+    "customTitle": "Statistics",
+    "dateFormat": "DD.MM.YYYY",
+    "locale": "de",
+    "labels": {
+      "download": "Download",
+      "ping": "Ping",
+      "upload": "Upload"
+    },
+    "daterange": {
+      "timePicker": true,
+      "timePicker24Hour": true,
+      "startDate": moment().startOf('day'),
+      "endDate": moment().endOf('day'),
+      ranges: {
+        'Today': [moment().hours(0).minutes(0).seconds(0), moment().hours(23).minutes(59).seconds(59)],
+        'Yesterday': [moment().hours(0).minutes(0).seconds(0).subtract(1, 'days'), moment().hours(23).minutes(59).seconds(59).subtract(1, 'days')],
+        'Last 7 Days': [moment().subtract(6, 'days'), moment()],
+        'Last 30 Days': [moment().subtract(29, 'days'), moment()],
+        'This Month': [moment().startOf('month'), moment().endOf('month')],
+        'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
+      }
     }
   }
 };


### PR DESCRIPTION
JS variables defined using `let` cannot be redefined, but variables
defined using var can. These changes allow the user to simply copy
the file to their data directory and then change the settings they
want to change. The settings in the data directory will override the
default ones in appConfig.example.js.

I also moved the order the config files are loaded by index.html so
the data file is given preference.